### PR TITLE
Port to 1.21.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.9-SNAPSHOT'
+    id 'fabric-loom' version '1.10-SNAPSHOT'
     id 'com.matthewprenger.cursegradle' version '1.4.0'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'com.modrinth.minotaur' version '2.+'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
 org.gradle.jvmargs=-Xmx2G
-minecraft_version=1.21.4
-minecraft_dependency=1.21.4
-curseforge_minecraft_version=1.21.4
+minecraft_version=1.21.6
+minecraft_dependency=1.21.6
+curseforge_minecraft_version=1.21.6
 
 configbuilder_version=1.1.3
 jlayer_version=1.0.1
 
-voicechat_api_version=2.5.0
-voicechat_mod_version=1.21.4-2.5.27
+voicechat_api_version=2.5.27
+voicechat_mod_version=1.21.6-2.5.30
 
-loader_version=0.16.9
-fabric_version=0.113.0+1.21.4
+loader_version=0.16.14
+fabric_version=0.127.1+1.21.6
 mod_base_version=1.1.1
-mod_version_meta=1.21.4.fabric
+mod_version_meta=1.21.6.fabric
 maven_group=de.maxhenkel.radio
 archives_base_name=radio
 mod_id=radio

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/de/maxhenkel/radio/mixin/SkullBlockEntityMixin.java
+++ b/src/main/java/de/maxhenkel/radio/mixin/SkullBlockEntityMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.ValueInput;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -30,7 +31,7 @@ public class SkullBlockEntityMixin extends BlockEntity {
     }
 
     @Inject(method = "loadAdditional", at = @At("RETURN"))
-    public void load(CompoundTag compoundTag, HolderLookup.Provider provider, CallbackInfo ci) {
+    public void load(ValueInput valueInput, CallbackInfo ci) {
         if (level != null && !level.isClientSide) {
             RadioManager.getInstance().onLoadHead((SkullBlockEntity) (Object) this);
         }

--- a/src/main/java/de/maxhenkel/radio/utils/HeadUtils.java
+++ b/src/main/java/de/maxhenkel/radio/utils/HeadUtils.java
@@ -7,22 +7,16 @@ import com.mojang.authlib.minecraft.MinecraftProfileTexture;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
 import com.mojang.util.UUIDTypeAdapter;
-import de.maxhenkel.radio.Radio;
+import it.unimi.dsi.fastutil.objects.ReferenceSortedSets;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.NbtUtils;
-import net.minecraft.nbt.StringTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.util.Unit;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.PlayerHeadItem;
 import net.minecraft.world.item.component.ItemLore;
 import net.minecraft.world.item.component.ResolvableProfile;
-import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.item.component.TooltipDisplay;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -45,7 +39,7 @@ public class HeadUtils {
 
         stack.set(DataComponents.ITEM_NAME, nameComponent);
         stack.set(DataComponents.LORE, lore);
-        stack.set(DataComponents.HIDE_ADDITIONAL_TOOLTIP, Unit.INSTANCE); // why not a boolean? uhm?
+        stack.set(DataComponents.TOOLTIP_DISPLAY, new TooltipDisplay(false, ReferenceSortedSets.singleton(DataComponents.PROFILE)));
         stack.set(DataComponents.PROFILE, resolvableProfile);
 
         return stack;


### PR DESCRIPTION
This is a quick and simple port to 1.21.6.  
  
Nothing much had to be changed, just bumped some versions.  
In addition:
- The hide_tooltip component does not exist anymore, so I replaced it with this:
`stack.set(DataComponents.TOOLTIP_DISPLAY, new TooltipDisplay(false, ReferenceSortedSets.singleton(DataComponents.PROFILE)));` which seems to work fine
- `SkullBlockEntity#load` changed, so I adjusted it.
  
I tested it locally and everything seems to work fine.